### PR TITLE
Exposing port 80 on host to port 80 on nginx container in prod docker compose file

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
       - static_volume_prod:/home/app/web/app/static
       - media_volume_prod:/home/app/web/app/media
     ports:
-      - 127.0.0.1:1337:80
+      - 80:80
 
 volumes:
   postgres_data_prod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./app/:/usr/src/app/
     ports:
-      - 8000:8000
+      - 127.0.0.1:8000:8000
     env_file: .env
 
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./app/:/usr/src/app/
     ports:
-      - 127.0.0.1:8000:8000
+      - 8000:8000
     env_file: .env
 
   db:


### PR DESCRIPTION
Changed from exposing nginx on port 1337 to port 80 instead in production docker-compose file so that we can run in production mode.