### PR TITLE
added STATICFILES_FINDERS to base settings

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -120,9 +120,13 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
+
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+]
 
 STATIC_ROOT = path.join(BASE_DIR, 'static')
 STATIC_URL = environ.get("STATIC_URL", '/static/')


### PR DESCRIPTION

## What is included in this pull request

added STATICFILES_FINDERS to base settings in order to detect static files. Will now detect static files in a 'static' subdirectory for any app module. E.g. farm/static/css/*.css or homepage/static/js/*.css. Also loads static files in the app/static folder.

## How to test

- Add a CSS rule to the CSS file in `app/static/css`, like `background-color` or change the size of `H1`.
- Reload `localhost:8000`.
- You should see that the myfarm.css file loads and the styles display as expected.
- May need to hard refresh the page in case it is cached.