### PR TITLE
feature/MY74-link-views-together-in-landing-page

### DIFF
--- a/app/app/settings/base.py
+++ b/app/app/settings/base.py
@@ -132,3 +132,5 @@ STATIC_URL = environ.get("STATIC_URL", '/static/')
 MEDIA_ROOT = path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
+LOGOUT_REDIRECT_URL = '/'
+

--- a/app/app/templates/base.html
+++ b/app/app/templates/base.html
@@ -17,6 +17,7 @@
     <body>
 
         <script  src="https://code.jquery.com/jquery-3.6.0.min.js"   integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="  crossorigin="anonymous"></script>
+        {% include "header.html" %}
         {% block content %}{% endblock %}
 
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>

--- a/app/app/templates/header.html
+++ b/app/app/templates/header.html
@@ -1,0 +1,13 @@
+<div>
+  <ul>
+  {% if not request.user.id %}
+  <li><a href="/register">Sign-up as a farmer</a></li>
+  <li><a href="/register/login">Login</a></li>
+  {% endif %}
+  {% if request.user.id %}
+    <li><a href="/farm/">My farm</a></li>
+    <li><a href="/register/logout">Logout</a></li>
+  {% endif %}
+  
+  </ul>
+</div>

--- a/app/authenticate/tests/test_views.py
+++ b/app/authenticate/tests/test_views.py
@@ -1,7 +1,9 @@
+from django.http import request
 from django.test import TestCase, Client
 from authenticate.forms import SignUpForm
 from homepage.views import homepage
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, authenticate
+from django.contrib.auth.models import User
 
 valid_form_data = {
   "username": "username",
@@ -106,3 +108,12 @@ class LoginTest(TestCase):
         response = self.client.login(username='temporary', password='temporary')
         self.assertNotEqual(response, True)
         
+class LogoutTest(TestCase):
+
+    def test_logout_view_redirects_to_homepage(self):
+        response = c.get('/register/logout')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')
+
+        
+

--- a/app/authenticate/urls.py
+++ b/app/authenticate/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 from . import views
 from .forms import UserLogin
+from django.contrib.auth.views import LogoutView
 
 app_name='authenticate'
 urlpatterns = [
   path('', views.user_register, name='user_register'),
   path('login/', UserLogin.as_view(), name='user_login'),
+  path('logout', LogoutView.as_view(), name='user_logout')
 ]


### PR DESCRIPTION
### What is included in this pull request**
* Added the default `logout` view, and added the `settings.LOGOUT_URL` parameter setting the redirect after logout to the home page
* Adding login, create account, my farm, and logout links to the home page
* Login and created account are visible to anonymous users
* Logout and My Farm links are visible to logged in users

### How to test
* Pull this branch, launch the application, then go to localhost:8000
* Before being logged in, you should see two links in a list at the top left of the screen: Login and "Sign-up as a farmer'.
* Once logged in, you should see Logout and "My Farm" links
* After clicking "Log out", you should be redirected to the home page